### PR TITLE
Add support for in-memory string via string: true option

### DIFF
--- a/lib/gitignore-to-glob.js
+++ b/lib/gitignore-to-glob.js
@@ -11,10 +11,29 @@
 const fs = require('fs');
 const path = require('path');
 
-module.exports = (gitignorePath, dirsToCheck) => {
-    gitignorePath = path.resolve(gitignorePath || '.gitignore');
+const loadGitignoreContents = function (pathOrContents, isContents) {
+    if (isContents === true) {
+        return pathOrContents;
+    }
 
-    return fs.readFileSync(gitignorePath, {encoding: 'utf8'})
+    const gitignorePath = path.resolve(pathOrContents || '.gitignore');
+    return fs.readFileSync(gitignorePath, {encoding: 'utf8'});
+};
+
+module.exports = (gitignore, options) => {
+    let dirsToCheck;
+    let gitignoreIsInMemoryString = false;
+
+    if (Array.isArray(options)) {
+        dirsToCheck = options;
+    } else if (typeof options === 'object') {
+        dirsToCheck = options.dirsToCheck;
+        gitignoreIsInMemoryString = options.string;
+    }
+
+    const gitignoreContents = loadGitignoreContents(gitignore, gitignoreIsInMemoryString);
+
+    return gitignoreContents
         .split('\n')
 
         // Filter out empty lines and comments.

--- a/test/spec.js
+++ b/test/spec.js
@@ -56,4 +56,9 @@ describe('gitignoreToGlob', () => {
         assertNotContain(processedArray, '!pattern2');
         assertContain(processedArray, '!pattern3');
     });
+
+    it('should treat gitignore as in-memory string with string:true option', () => {
+        const result = gitignoreToGlob('node_modules', {string: true});
+        assert.deepEqual(result, ['!**/node_modules', '!**/node_modules/**']);
+    });
 });


### PR DESCRIPTION
In case you already have the contents of the gitignore file loaded, use that string instead of loading the file again. This maintains the existing interface for backwards compatibility while introducing a more flexible `options` second argument to enable multiple options to be provided.