### PR TITLE
Dont duplicate / if item already ends in it

### DIFF
--- a/lib/gitignore-to-glob.js
+++ b/lib/gitignore-to-glob.js
@@ -53,10 +53,19 @@ module.exports = (gitignorePath, dirsToCheck) => {
 
         // We don't know whether a pattern points to a directory or a file and we need files.
         // Therefore, include both `pattern` and `pattern/**` for every pattern in the array.
+        // If pattern ends with /, we want to ignore that dir and its contents so include both
+        // stripped `/` and added `**`.
         .reduce((result, patternPair) => {
             const pattern = patternPair.join('');
-            result.push(pattern);
-            result.push(`${ pattern }/**`);
+
+            if (pattern[pattern.length - 1] === '/') {
+                result.push(pattern.substring(0, pattern.length - 1));
+                result.push(`${ pattern }**`);
+            } else {
+                result.push(pattern);
+                result.push(`${ pattern }/**`);
+            }
+
             return result;
         }, []);
 };

--- a/test/fixtures/gitignore-ending-slash
+++ b/test/fixtures/gitignore-ending-slash
@@ -1,0 +1,1 @@
+pattern/

--- a/test/spec.js
+++ b/test/spec.js
@@ -56,4 +56,8 @@ describe('gitignoreToGlob', () => {
         assertNotContain(processedArray, '!pattern2');
         assertContain(processedArray, '!pattern3');
     });
+
+    it('should not duplicate the / when path ends with /', () => {
+        assertDeep('ending-slash', ['!**/pattern', '!**/pattern/**']);
+    });
 });


### PR DESCRIPTION
Currently, if gitignore contains `dir/` we end up with `!dir/` and `!dir//**` — the globs that we actually want in this case are `!dir` (to ignore that directory itself) and `!dir/**` to ignore all subdirectories.